### PR TITLE
Change Redis Store to Database Store Mention

### DIFF
--- a/content/docs/security/rate-limiter.md
+++ b/content/docs/security/rate-limiter.md
@@ -239,7 +239,7 @@ Reject the rate-limiting requests when the status of the Redis connection is not
 ---
 
 ### Database store
-The `database` store has a peer dependency on the `@adonisjs/lucid` package, and therefore, you must configure this package before using the Redis store.
+The `database` store has a peer dependency on the `@adonisjs/lucid` package, and therefore, you must configure this package before using the Database store.
 
 Following is the list of options the database store accepts (alongside the shared options).
 


### PR DESCRIPTION
In the section discussing Database store implementations in the Rate Limiter page, there was a reference to using Redis store instead of Database store. To maintain accuracy and clarity for users, I have corrected this discrepancy to accurately reflect the utilization of a Database store.

