### PR TITLE
docs: Update mail references to message

### DIFF
--- a/content/docs/mail/message.md
+++ b/content/docs/mail/message.md
@@ -20,7 +20,7 @@ await mail.sendLater((message) => {
 ```
 
 ## Defining subject and sender
-You may define the email subject using the `message.subject` method and the email's sender using the `mail.from` method.
+You may define the email subject using the `message.subject` method and the email's sender using the `message.from` method.
 
 ```ts
 await mail.send((message) => {


### PR DESCRIPTION
This PR updates the documentation to replace instances of `mail` with `message` for consistency with the codebase and to avoid confusion.

The affected line was:

"You may define the email subject using the `message.subject` method and the email's sender using the `mail.from` method."

It has been updated to:

"You may define the email subject using the `message.subject` method and the email's sender using the `message.from` method."

